### PR TITLE
Add CI workflows for CanonicalLayouts samples

### DIFF
--- a/.github/workflows/feed-compose-build.yml
+++ b/.github/workflows/feed-compose-build.yml
@@ -1,0 +1,33 @@
+# Workflow name
+name: Build feed-compose
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set Up JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: '17'
+          cache: 'gradle'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Make gradlew executable
+        run: chmod +x ./gradlew
+        working-directory: ./adaptive-apps-samples/CanonicalLayouts/feed-compose
+
+      - name: Build feed-compose app
+        working-directory: ./adaptive-apps-samples/CanonicalLayouts/feed-compose
+        run: ./gradlew :app:assembleDebug

--- a/.github/workflows/feed-view-build.yml
+++ b/.github/workflows/feed-view-build.yml
@@ -1,0 +1,33 @@
+# Workflow name
+name: Build feed-view
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set Up JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: '17'
+          cache: 'gradle'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Make gradlew executable
+        run: chmod +x ./gradlew
+        working-directory: ./adaptive-apps-samples/CanonicalLayouts/feed-view
+
+      - name: Build feed-view app
+        working-directory: ./adaptive-apps-samples/CanonicalLayouts/feed-view
+        run: ./gradlew :app:assembleDebug

--- a/.github/workflows/list-detail-activity-embedding-build.yml
+++ b/.github/workflows/list-detail-activity-embedding-build.yml
@@ -1,0 +1,33 @@
+# Workflow name
+name: Build list-detail-activity-embedding
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set Up JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: '17'
+          cache: 'gradle'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Make gradlew executable
+        run: chmod +x ./gradlew
+        working-directory: ./adaptive-apps-samples/CanonicalLayouts/list-detail-activity-embedding
+
+      - name: Build list-detail-activity-embedding app
+        working-directory: ./adaptive-apps-samples/CanonicalLayouts/list-detail-activity-embedding
+        run: ./gradlew :app:assembleDebug

--- a/.github/workflows/list-detail-compose-build.yml
+++ b/.github/workflows/list-detail-compose-build.yml
@@ -1,0 +1,33 @@
+# Workflow name
+name: Build list-detail-compose
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set Up JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: '17'
+          cache: 'gradle'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Make gradlew executable
+        run: chmod +x ./gradlew
+        working-directory: ./adaptive-apps-samples/CanonicalLayouts/list-detail-compose
+
+      - name: Build list-detail-compose app
+        working-directory: ./adaptive-apps-samples/CanonicalLayouts/list-detail-compose
+        run: ./gradlew :app:assembleDebug

--- a/.github/workflows/list-detail-sliding-pane-build.yml
+++ b/.github/workflows/list-detail-sliding-pane-build.yml
@@ -1,0 +1,33 @@
+# Workflow name
+name: Build list-detail-sliding-pane
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set Up JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: '17'
+          cache: 'gradle'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Make gradlew executable
+        run: chmod +x ./gradlew
+        working-directory: ./adaptive-apps-samples/CanonicalLayouts/list-detail-sliding-pane
+
+      - name: Build list-detail-sliding-pane app
+        working-directory: ./adaptive-apps-samples/CanonicalLayouts/list-detail-sliding-pane
+        run: ./gradlew :app:assembleDebug

--- a/.github/workflows/supporting-pane-compose-build.yml
+++ b/.github/workflows/supporting-pane-compose-build.yml
@@ -1,0 +1,33 @@
+# Workflow name
+name: Build supporting-pane-compose
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set Up JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: '17'
+          cache: 'gradle'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Make gradlew executable
+        run: chmod +x ./gradlew
+        working-directory: ./adaptive-apps-samples/CanonicalLayouts/supporting-pane-compose
+
+      - name: Build supporting-pane-compose app
+        working-directory: ./adaptive-apps-samples/CanonicalLayouts/supporting-pane-compose
+        run: ./gradlew :app:assembleDebug

--- a/.github/workflows/supporting-pane-fragments-build.yml
+++ b/.github/workflows/supporting-pane-fragments-build.yml
@@ -1,0 +1,33 @@
+# Workflow name
+name: Build supporting-pane-fragments
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set Up JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: '17'
+          cache: 'gradle'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Make gradlew executable
+        run: chmod +x ./gradlew
+        working-directory: ./adaptive-apps-samples/CanonicalLayouts/supporting-pane-fragments
+
+      - name: Build supporting-pane-fragments app
+        working-directory: ./adaptive-apps-samples/CanonicalLayouts/supporting-pane-fragments
+        run: ./gradlew :app:assembleDebug

--- a/.github/workflows/supporting-pane-views-build.yml
+++ b/.github/workflows/supporting-pane-views-build.yml
@@ -1,0 +1,33 @@
+# Workflow name
+name: Build supporting-pane-views
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set Up JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: '17'
+          cache: 'gradle'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Make gradlew executable
+        run: chmod +x ./gradlew
+        working-directory: ./adaptive-apps-samples/CanonicalLayouts/supporting-pane-views
+
+      - name: Build supporting-pane-views app
+        working-directory: ./adaptive-apps-samples/CanonicalLayouts/supporting-pane-views
+        run: ./gradlew :app:assembleDebug


### PR DESCRIPTION
This commit adds CI workflows to build each of the CanonicalLayouts samples. These workflows will
run manually with workflow_dispatch and on
push and pull request to the main branch.

The following workflows were added:

- feed-compose-build.yml
- feed-view-build.yml
- list-detail-activity-embedding-build.yml
- list-detail-compose-build.yml
- list-detail-sliding-pane-build.yml
- supporting-pane-compose-build.yml
- supporting-pane-fragments-build.yml
- supporting-pane-views-build.yml