### PR TITLE
Fix CanonicalLayouts CI workflows directory

### DIFF
--- a/.github/workflows/feed-compose-build.yml
+++ b/.github/workflows/feed-compose-build.yml
@@ -26,8 +26,8 @@ jobs:
 
       - name: Make gradlew executable
         run: chmod +x ./gradlew
-        working-directory: ./adaptive-apps-samples/CanonicalLayouts/feed-compose
+        working-directory: ./CanonicalLayouts/feed-compose
 
       - name: Build feed-compose app
-        working-directory: ./adaptive-apps-samples/CanonicalLayouts/feed-compose
+        working-directory: ./CanonicalLayouts/feed-compose
         run: ./gradlew :app:assembleDebug

--- a/.github/workflows/feed-view-build.yml
+++ b/.github/workflows/feed-view-build.yml
@@ -26,8 +26,8 @@ jobs:
 
       - name: Make gradlew executable
         run: chmod +x ./gradlew
-        working-directory: ./adaptive-apps-samples/CanonicalLayouts/feed-view
+        working-directory: ./CanonicalLayouts/feed-view
 
       - name: Build feed-view app
-        working-directory: ./adaptive-apps-samples/CanonicalLayouts/feed-view
+        working-directory: ./CanonicalLayouts/feed-view
         run: ./gradlew :app:assembleDebug

--- a/.github/workflows/list-detail-activity-embedding-build.yml
+++ b/.github/workflows/list-detail-activity-embedding-build.yml
@@ -26,8 +26,8 @@ jobs:
 
       - name: Make gradlew executable
         run: chmod +x ./gradlew
-        working-directory: ./adaptive-apps-samples/CanonicalLayouts/list-detail-activity-embedding
+        working-directory: ./CanonicalLayouts/list-detail-activity-embedding
 
       - name: Build list-detail-activity-embedding app
-        working-directory: ./adaptive-apps-samples/CanonicalLayouts/list-detail-activity-embedding
+        working-directory: ./CanonicalLayouts/list-detail-activity-embedding
         run: ./gradlew :app:assembleDebug

--- a/.github/workflows/list-detail-compose-build.yml
+++ b/.github/workflows/list-detail-compose-build.yml
@@ -26,8 +26,8 @@ jobs:
 
       - name: Make gradlew executable
         run: chmod +x ./gradlew
-        working-directory: ./adaptive-apps-samples/CanonicalLayouts/list-detail-compose
+        working-directory: ./CanonicalLayouts/list-detail-compose
 
       - name: Build list-detail-compose app
-        working-directory: ./adaptive-apps-samples/CanonicalLayouts/list-detail-compose
+        working-directory: ./CanonicalLayouts/list-detail-compose
         run: ./gradlew :app:assembleDebug

--- a/.github/workflows/list-detail-sliding-pane-build.yml
+++ b/.github/workflows/list-detail-sliding-pane-build.yml
@@ -26,8 +26,8 @@ jobs:
 
       - name: Make gradlew executable
         run: chmod +x ./gradlew
-        working-directory: ./adaptive-apps-samples/CanonicalLayouts/list-detail-sliding-pane
+        working-directory: ./CanonicalLayouts/list-detail-sliding-pane
 
       - name: Build list-detail-sliding-pane app
-        working-directory: ./adaptive-apps-samples/CanonicalLayouts/list-detail-sliding-pane
+        working-directory: ./CanonicalLayouts/list-detail-sliding-pane
         run: ./gradlew :app:assembleDebug

--- a/.github/workflows/supporting-pane-compose-build.yml
+++ b/.github/workflows/supporting-pane-compose-build.yml
@@ -26,8 +26,8 @@ jobs:
 
       - name: Make gradlew executable
         run: chmod +x ./gradlew
-        working-directory: ./adaptive-apps-samples/CanonicalLayouts/supporting-pane-compose
+        working-directory: ./CanonicalLayouts/supporting-pane-compose
 
       - name: Build supporting-pane-compose app
-        working-directory: ./adaptive-apps-samples/CanonicalLayouts/supporting-pane-compose
+        working-directory: ./CanonicalLayouts/supporting-pane-compose
         run: ./gradlew :app:assembleDebug

--- a/.github/workflows/supporting-pane-fragments-build.yml
+++ b/.github/workflows/supporting-pane-fragments-build.yml
@@ -26,8 +26,8 @@ jobs:
 
       - name: Make gradlew executable
         run: chmod +x ./gradlew
-        working-directory: ./adaptive-apps-samples/CanonicalLayouts/supporting-pane-fragments
+        working-directory: ./CanonicalLayouts/supporting-pane-fragments
 
       - name: Build supporting-pane-fragments app
-        working-directory: ./adaptive-apps-samples/CanonicalLayouts/supporting-pane-fragments
+        working-directory: ./CanonicalLayouts/supporting-pane-fragments
         run: ./gradlew :app:assembleDebug

--- a/.github/workflows/supporting-pane-views-build.yml
+++ b/.github/workflows/supporting-pane-views-build.yml
@@ -26,8 +26,8 @@ jobs:
 
       - name: Make gradlew executable
         run: chmod +x ./gradlew
-        working-directory: ./adaptive-apps-samples/CanonicalLayouts/supporting-pane-views
+        working-directory: ./CanonicalLayouts/supporting-pane-views
 
       - name: Build supporting-pane-views app
-        working-directory: ./adaptive-apps-samples/CanonicalLayouts/supporting-pane-views
+        working-directory: ./CanonicalLayouts/supporting-pane-views
         run: ./gradlew :app:assembleDebug


### PR DESCRIPTION
This commit fixes the working directory for the
CanonicalLayouts CI workflows. The directory was
incorrectly pointing to
`./adaptive-apps-samples/CanonicalLayouts/*` instead of `./CanonicalLayouts/*`.

The following workflows were updated:

- feed-compose-build.yml
- feed-view-build.yml
- list-detail-activity-embedding-build.yml
- list-detail-compose-build.yml
- list-detail-sliding-pane-build.yml
- supporting-pane-compose-build.yml
- supporting-pane-fragments-build.yml
- supporting-pane-views-build.yml