### PR TITLE
Visual issue with NavigationSuiteScaffold on XR emulator

### DIFF
--- a/AdaptiveJetStream/jetstream/src/main/java/com/google/jetstream/presentation/App.kt
+++ b/AdaptiveJetStream/jetstream/src/main/java/com/google/jetstream/presentation/App.kt
@@ -16,6 +16,7 @@
 
 package com.google.jetstream.presentation
 
+import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
@@ -24,8 +25,10 @@ import androidx.compose.ui.input.key.Key
 import androidx.navigation.compose.rememberNavController
 import com.google.jetstream.presentation.app.AppState
 import com.google.jetstream.presentation.app.NavigationComponentType
+import com.google.jetstream.presentation.app.NavigationTree
 import com.google.jetstream.presentation.app.rememberAppState
 import com.google.jetstream.presentation.app.rememberNavigationComponentType
+import com.google.jetstream.presentation.app.updateTopBarVisibility
 import com.google.jetstream.presentation.app.withNavigationSuiteScaffold.AppWithNavigationSuiteScaffold
 import com.google.jetstream.presentation.app.withNavigationSuiteScaffold.EnableProminentMovieListOverride
 import com.google.jetstream.presentation.app.withTopBarNavigation.AppWithTopBarNavigation
@@ -141,11 +144,18 @@ fun App(
     when (navigationComponentType) {
         NavigationComponentType.NavigationSuiteScaffold -> {
             EnableProminentMovieListOverride {
-                AppWithNavigationSuiteScaffold(
+
+                NavigationTree(
                     appState = appState,
                     navController = navController,
-                    modifier = modifier.handleKeyboardShortcuts(keyboardShortcuts),
+                    isTopBarVisible = appState.isTopBarVisible,
+                    onScroll = { updateTopBarVisibility(appState, it) }
                 )
+                /*  AppWithNavigationSuiteScaffold(
+                      appState = appState,
+                      navController = navController,
+                      modifier = modifier.handleKeyboardShortcuts(keyboardShortcuts),
+                  )*/
             }
         }
 

--- a/AdaptiveJetStream/jetstream/src/main/java/com/google/jetstream/presentation/app/NavigationTree.kt
+++ b/AdaptiveJetStream/jetstream/src/main/java/com/google/jetstream/presentation/app/NavigationTree.kt
@@ -22,6 +22,7 @@ import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import com.google.jetstream.data.entities.Movie
+import com.google.jetstream.presentation.app.withNavigationSuiteScaffold.AppWithNavigationSuiteScaffold
 import com.google.jetstream.presentation.screens.Screens.Categories
 import com.google.jetstream.presentation.screens.Screens.CategoryMovieList
 import com.google.jetstream.presentation.screens.Screens.Favourites
@@ -47,6 +48,7 @@ import com.google.jetstream.presentation.screens.videoPlayer.VideoPlayerScreen
 
 @Composable
 fun NavigationTree(
+    appState: AppState,
     navController: NavHostController,
     modifier: Modifier = Modifier,
     isTopBarVisible: Boolean = true,
@@ -93,39 +95,49 @@ fun NavigationTree(
             ProfileScreen()
         }
         composable(Home()) {
-            HomeScreen(
-                onMovieClick = { movie -> navController.openMovieDetailsScreen(movie.id) },
-                goToVideoPlayer = { movie: Movie -> navController.openVideoPlayer(movie.id) },
-                onScroll = onScroll,
-                isTopBarVisible = isTopBarVisible
-            )
+            AppWithNavigationSuiteScaffold(appState,navController,modifier) {
+                HomeScreen(
+                    onMovieClick = { movie -> navController.openMovieDetailsScreen(movie.id) },
+                    goToVideoPlayer = { movie: Movie -> navController.openVideoPlayer(movie.id) },
+                    onScroll = onScroll,
+                    isTopBarVisible = isTopBarVisible
+                )
+            }
         }
         composable(Categories()) {
-            CategoriesScreen(
-                onCategoryClick = navController.openCategoryMovieList(),
-                onScroll = onScroll,
-            )
+            AppWithNavigationSuiteScaffold(appState,navController,modifier) {
+                CategoriesScreen(
+                    onCategoryClick = navController.openCategoryMovieList(),
+                    onScroll = onScroll,
+                )
+            }
         }
         composable(Movies()) {
-            MoviesScreen(
-                onMovieClick = { movie -> navController.openMovieDetailScreen(movie) },
-                onScroll = onScroll,
-                isTopBarVisible = isTopBarVisible
-            )
+            AppWithNavigationSuiteScaffold(appState,navController,modifier) {
+                MoviesScreen(
+                    onMovieClick = { movie -> navController.openMovieDetailScreen(movie) },
+                    onScroll = onScroll,
+                    isTopBarVisible = isTopBarVisible
+                )
+            }
         }
         composable(Shows()) {
-            ShowsScreen(
-                onTVShowClick = { movie -> navController.openMovieDetailScreen(movie) },
-                onScroll = onScroll,
-                isTopBarVisible = isTopBarVisible
-            )
+            AppWithNavigationSuiteScaffold(appState,navController,modifier) {
+                ShowsScreen(
+                    onTVShowClick = { movie -> navController.openMovieDetailScreen(movie) },
+                    onScroll = onScroll,
+                    isTopBarVisible = isTopBarVisible
+                )
+            }
         }
         composable(Favourites()) {
-            FavouritesScreen(
-                onMovieClick = navController::openMovieDetailsScreen,
-                onScroll = onScroll,
-                isTopBarVisible = isTopBarVisible
-            )
+            AppWithNavigationSuiteScaffold(appState,navController,modifier) {
+                FavouritesScreen(
+                    onMovieClick = navController::openMovieDetailsScreen,
+                    onScroll = onScroll,
+                    isTopBarVisible = isTopBarVisible
+                )
+            }
         }
         composable(Search()) {
             SearchScreen(

--- a/AdaptiveJetStream/jetstream/src/main/java/com/google/jetstream/presentation/app/withNavigationSuiteScaffold/AppWithNavigationSuiteScaffold.kt
+++ b/AdaptiveJetStream/jetstream/src/main/java/com/google/jetstream/presentation/app/withNavigationSuiteScaffold/AppWithNavigationSuiteScaffold.kt
@@ -19,6 +19,7 @@ package com.google.jetstream.presentation.app.withNavigationSuiteScaffold
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
@@ -47,6 +48,7 @@ fun AppWithNavigationSuiteScaffold(
     appState: AppState,
     navController: NavHostController,
     modifier: Modifier = Modifier,
+    content: @Composable (PaddingValues) -> Unit,
 ) {
 
     val navigationSuiteScaffoldState = rememberNavigationSuiteScaffoldState()
@@ -123,12 +125,13 @@ fun AppWithNavigationSuiteScaffold(
                 }
             }
         ) { padding ->
-            NavigationTree(
+            content(padding)
+            /*NavigationTree(
                 navController = navController,
                 isTopBarVisible = appState.isTopBarVisible,
                 modifier = modifier.padding(padding),
                 onScroll = { updateTopBarVisibility(appState, it) }
-            )
+            )*/
         }
     }
 }

--- a/AdaptiveJetStream/jetstream/src/main/java/com/google/jetstream/presentation/app/withTopBarNavigation/AppWithTopBarNavigation.kt
+++ b/AdaptiveJetStream/jetstream/src/main/java/com/google/jetstream/presentation/app/withTopBarNavigation/AppWithTopBarNavigation.kt
@@ -72,7 +72,7 @@ fun AppWithTopBarNavigation(
     ) {
         AnimatedVisibility(
             appState.isNavigationVisible &&
-                appState.isTopBarVisible
+                    appState.isTopBarVisible
         ) {
             TopBar(
                 items,
@@ -94,6 +94,7 @@ fun AppWithTopBarNavigation(
             )
         }
         NavigationTree(
+            appState = appState,
             navController = navController,
             isTopBarVisible = appState.isTopBarVisible,
             onScroll = { updateTopBarVisibility(appState, it) }


### PR DESCRIPTION
In our project, we encountered a visual issue involving a screen overlay when switching between tabs on the XR emulator. This PR was created to demonstrate the issue using the JetStream app.
The issue is documented here: https://issuetracker.google.com/issues/435102848

To reproduce the issue, each screen is wrapped in AppWithNavigationSuiteScaffold instead of wrapping only the NavigationTree. This setup showcases the UI problem: when switching tabs, a blank overlay appears over the app content.

<img width="946" height="946" alt="Screenshot 2025-07-30 at 12 02 52" src="https://github.com/user-attachments/assets/24be8aaf-56b0-4a26-9aba-994ff4283ac1" />



https://github.com/user-attachments/assets/4a4b678e-ea5e-4ad1-8ff9-77ffe3780380


