### PR TITLE
Fix duplicate title on compact profile screen

### DIFF
--- a/AdaptiveJetStream/jetstream/src/main/java/com/google/jetstream/presentation/screens/profile/ProfileScreen.kt
+++ b/AdaptiveJetStream/jetstream/src/main/java/com/google/jetstream/presentation/screens/profile/ProfileScreen.kt
@@ -310,6 +310,7 @@ private fun CompactProfileScreen() {
                             ProfileScreens.About -> AboutSection()
                             ProfileScreens.Subtitles ->
                                 SubtitlesSection(
+                                    isExpanded = false,
                                     isSubtitlesChecked = isSubtitlesChecked,
                                     onSubtitleCheckChange = { isSubtitlesChecked = it }
                                 )
@@ -321,8 +322,13 @@ private fun CompactProfileScreen() {
                                     onSelectedIndexChange = { selectedLanguageIndex = it }
                                 )
 
-                            ProfileScreens.SearchHistory -> SearchHistorySection()
-                            ProfileScreens.HelpAndSupport -> HelpAndSupportSection()
+                            ProfileScreens.SearchHistory -> SearchHistorySection(
+                                isExpanded = false
+                            )
+
+                            ProfileScreens.HelpAndSupport -> HelpAndSupportSection(
+                                isExpanded = false
+                            )
                         }
                     }
                 }

--- a/AdaptiveJetStream/jetstream/src/main/java/com/google/jetstream/presentation/screens/profile/ProfileScreen.kt
+++ b/AdaptiveJetStream/jetstream/src/main/java/com/google/jetstream/presentation/screens/profile/ProfileScreen.kt
@@ -316,6 +316,7 @@ private fun CompactProfileScreen() {
 
                             ProfileScreens.Language ->
                                 LanguageSection(
+                                    isExpanded = false,
                                     selectedIndex = selectedLanguageIndex,
                                     onSelectedIndexChange = { selectedLanguageIndex = it }
                                 )


### PR DESCRIPTION
## Summary

Fixes a UI issue where section titles were displayed twice on the compact (phone) profile screens.

## Root Cause

Several profile sections defaulted to `isExpanded = true`, causing section titles to be rendered even when the compact layout already provides a header.

## Changes

- Pass `isExpanded = false` when rendering profile sections in the compact layout.
- Remove duplicate section titles from the phone experience.
- Preserve existing behavior for expanded layouts.

<img width="366" height="808" alt="Duplicate Language Label in Compact device" src="https://github.com/user-attachments/assets/2464ac23-71a7-43dd-a7c5-61a2e36d33c9" />
<img width="365" height="809" alt="Duplicate Language Label in Compact device - Fixed" src="https://github.com/user-attachments/assets/f44331b1-4b7c-4f22-b8d0-42d38982a4cc" />
